### PR TITLE
Add "log-always" option

### DIFF
--- a/logging.tmux
+++ b/logging.tmux
@@ -5,12 +5,15 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/scripts/variables.sh"
 source "$CURRENT_DIR/scripts/shared.sh"
 
-
 main() {
 	tmux bind-key "$logging_key" run-shell "$CURRENT_DIR/scripts/toggle_logging.sh"
 	tmux bind-key "$pane_screen_capture_key" run-shell "$CURRENT_DIR/scripts/screen_capture.sh"
 	tmux bind-key "$save_complete_history_key" run-shell "$CURRENT_DIR/scripts/save_complete_history.sh"
 	tmux bind-key "$clear_history_key" run-shell "$CURRENT_DIR/scripts/clear_history.sh"
+
+    if $log_always = "true"; then
+        tmux set-hook -g pane-focus-in 'run-shell "'$CURRENT_DIR'/scripts/set_logging_on.sh"'
+    fi
 }
 
 main

--- a/scripts/set_logging_on.sh
+++ b/scripts/set_logging_on.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/variables.sh"
+source "$CURRENT_DIR/shared.sh"
+
+set_logging_on() {
+    if ! is_logging; then
+        $CURRENT_DIR/toggle_logging.sh
+    fi
+}
+
+main() {
+    set_logging_on
+}
+main

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -53,3 +53,20 @@ expand_tmux_format_path() {
 	mkdir -p "${full_directory_path}"
 	echo "${full_path}"
 }
+
+# returns a string unique to current pane
+pane_unique_id() {
+	tmux display-message -p "#{session_name}_#{window_index}_#{pane_index}"
+}
+
+
+# this function checks if logging is happening for the current pane
+is_logging() {
+	local pane_unique_id="$(pane_unique_id)"
+	local current_pane_logging="$(get_tmux_option "@${pane_unique_id}" "not logging")"
+	if [ "$current_pane_logging" == "logging" ]; then
+		return 0
+	else
+		return 1
+	fi
+}

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -5,6 +5,7 @@ SUPPORTED_VERSION="1.9"
 default_logging_key="P" # Shift-p
 logging_key=$(tmux show-option -gqv "@logging_key")
 logging_key=${logging_key:-$default_logging_key}
+log_always=$(tmux show-option -gqv "@log-always")
 
 default_pane_screen_capture_key="M-p" # Alt-p
 pane_screen_capture_key=$(tmux show-option -gqv "@screen-capture-key")


### PR DESCRIPTION
Adds a log always option that allows causes all new panes (actually all entered
panes) to log always

This is done using the pane focus tmux hook.

Disabled by default, set by
```
set -g @log-always 'true'
```